### PR TITLE
Remove external dependencies from ucd-generate

### DIFF
--- a/private/ucd.rkt
+++ b/private/ucd.rkt
@@ -4,47 +4,41 @@
   racket/bool
   racket/file
   racket/logging
-  racket/system)
+  racket/port
+  net/url
+  file/unzip)
 
 (provide fetch-unicode-character-data)
 
-(define (ensure-command-installed command)
-  (when (false? (find-executable-path command))
-		(displayln (format "No ~a command installed" command) (current-error-port))
-		(exit -1)))
-
-(define (ensure-all-commands-installed . commands)
-  (for ([command commands])
-  	(ensure-command-installed command)))
-
-(define (curl base-url file-name into-path)
-  (log-info "curl ~a ~a ~a" base-url file-name into-path)
-  (let* ([output-file (path->string (build-path into-path file-name))]
-         [command (format "curl ~a~a -o ~a" base-url file-name output-file)])
+(define (download base-url file-name into-path)
+  (log-info "download ~a ~a ~a" base-url file-name (path->string into-path))
+  (let ([url (combine-url/relative (string->url base-url) file-name)]
+        [output-file (build-path into-path file-name)])
     (make-directory* into-path)
-    (when (false? (system command))
-    	    (displayln "failed to execute curl command correctly" (current-error-port))
-  	      (exit -2))))
+    (call-with-output-file output-file #:exists 'truncate/replace
+      (lambda (out-port)
+        (call/input-url url get-pure-port
+                        (lambda (in-port)
+                          (copy-port in-port out-port)))))))
 
-(define (curl-all fetch-all root-dir)
-  (log-info "curl-all")
+(define (download-all fetch-all root-dir)
+  (log-info "download-all")
   (for ([fetch-one fetch-all])
-  	(curl (car fetch-one) 
-          (cadr fetch-one) 
-          (build-path root-dir (caddr fetch-one)))))
+    (download (car fetch-one)
+              (cadr fetch-one)
+              (build-path root-dir (caddr fetch-one)))))
 
 (define (fetch-unicode-character-data root-dir)
   (log-info "fetch-unicode-character-data")
-  (ensure-all-commands-installed "curl" "unzip")
-  (curl-all 
+  (download-all
     '(("http://www.unicode.org/Public/UCD/latest/" "ReadMe.txt" "data")
       ("http://www.unicode.org/Public/UCD/latest/ucd/" "UCD.zip" "data")
       ("http://www.unicode.org/Public/UCD/latest/ucd/" "Unihan.zip" "data")
       ("http://www.unicode.org/Public/UCD/latest/charts/" "ReadMe.txt" "data/charts")
-      ("http://www.unicode.org/Public/UCD/latest/charts/" "CodeCharts.pdf" "data/charts")))
-  (when (false? (system (format "unzip -d data/ucd data/UCD.zip")))
-    	  (displayln "failed to execute unzip on UCD download" (current-error-port))
-  	    (exit -3))
+      ("http://www.unicode.org/Public/UCD/latest/charts/" "CodeCharts.pdf" "data/charts"))
+    root-dir)
+  (log-info "Unzipping UCD.zip")
+  (unzip "data/UCD.zip" (make-filesystem-entry-reader #:dest "data/ucd" #:exists 'truncate/replace))
   #t)
 
 

--- a/scribblings/generator.scrbl
+++ b/scribblings/generator.scrbl
@@ -17,7 +17,7 @@ used to create a set of data files according to the following steps.
   @item{If the temporary directory, @code{data}, is not present:
 	@itemlist[#:style 'ordered
 	  @item{create the temporary directory,}
-	  @item{use the curl command to download the required files, and}
+	  @item{download the required files, and}
 	  @item{unzip the @code{UCD.zip} file.}
     ]}
   @item{If the output directory, @code{generated}, is not present then create it.}


### PR DESCRIPTION
Instead of using external curl and unzip programs, download files and extract them using standard base Racket modules. That way it can be used on Windows etc. systems without those programs.